### PR TITLE
Fix ip veth command syntax in wgbench.sh

### DIFF
--- a/wgbench.sh
+++ b/wgbench.sh
@@ -21,7 +21,7 @@ cleanup() {
 	cleancmds="$@; ${cleancmds}"
 }
 
-ip link add wgbenchlink1 type veth peer wgbenchlink2 
+ip link add wgbenchlink1 type veth peer name wgbenchlink2 
 cleanup 'ip link del wgbenchlink1 2> /dev/null || true'
 cleanup 'ip link del wgbenchlink2 2> /dev/null || true'
 


### PR DESCRIPTION
Fixes the syntax of the veth link creation command.
Running without this fix results in the following error:
```Cannot find device "wgbenchlink2"```